### PR TITLE
Feature/persist clicked tab

### DIFF
--- a/apps/coaches/templates/coaches/coaches_update.html
+++ b/apps/coaches/templates/coaches/coaches_update.html
@@ -19,14 +19,10 @@
         <div class="col-sm-offset-4 col-sm-4">
           <form action="" method="post">
             {% csrf_token %}
-
             {{ form|crispy }}
-
             <br>
-            <a href="{% url 'sportregistrations:detail' sport_registration.pk %}"
-               class="btn btn-back">Back</a>
+            <a class="btn btn-back js-btn-back">Back</a>
             <button id="update_coach_btn" type="submit" class="btn btn-success">Update</button>
-
           </form>
         </div>
       </div>

--- a/apps/players/templates/players/players_update.html
+++ b/apps/players/templates/players/players_update.html
@@ -19,13 +19,10 @@
         <div class="col-sm-offset-4 col-sm-4">
           <form action="" method="post">
             {% csrf_token %}
-
             {{ form|crispy }}
-
             <br>
-            <a href="{% url 'sportregistrations:detail' sport_registration.pk %}" class="btn btn-back">Back</a>
+            <a class="btn btn-back js-btn-back">Back</a>
             <button id="update_player_btn" type="submit" class="btn btn-success">Update</button>
-
           </form>
         </div>
       </div>

--- a/apps/sports/templates/sports/sport_registration_detail.html
+++ b/apps/sports/templates/sports/sport_registration_detail.html
@@ -28,8 +28,8 @@
               </li>
             {% endfor %}
             {% if available_roles %}
-              <li role="presentation" class="{% if forloop.first %}active{% endif %}">
-                <a id="available-roles-nav-tab" href="#id_available_roles" role="tab" data-toggle="tab" class="nav-tab">
+              <li role="presentation" class="{% if forloop.first and tab is None or tab == 'available-roles' %}active{% endif %}">
+                <a id="available-roles-nav-tab" href="#id_available_roles" role="tab" data-toggle="tab" class="nav-tab" data-tab="available-roles">
                   Available Roles
                 </a>
               </li>
@@ -53,7 +53,7 @@
             {% endfor %}
 
             {% if available_roles %}
-              <div role="tabpanel" class="tab-pane {% if forloop.first %}active{% endif %}" id="id_available_roles">
+              <div role="tabpanel" class="tab-pane {% if forloop.first and tab is None or tab == 'available-roles' %}active{% endif %}" id="id_available_roles">
                 <br>
                 <table class="table table-thin-th-border">
                   <thead>

--- a/apps/sports/templates/sports/sport_registration_detail.html
+++ b/apps/sports/templates/sports/sport_registration_detail.html
@@ -21,8 +21,8 @@
           <br><br>
           <ul class="nav nav-tabs nav-justified" role="tablist">
             {% for role in sr_roles %}
-              <li role="presentation" class="{% if forloop.first %}active{% endif %}">
-                <a id="{{ role|lower }}_tab" href="#id_{{ role|lower }}" role="tab" data-toggle="tab" class="nav-tab">
+              <li role="presentation" class="{% if forloop.first and tab is None or tab == role|lower %}active{% endif %}">
+                <a id="{{ role|lower }}_tab" href="#id_{{ role|lower }}" role="tab" data-toggle="tab" class="nav-tab" data-tab="{{ role|lower }}">
                   {% pluralize_roles role %}
                 </a>
               </li>
@@ -38,7 +38,7 @@
 
           <div class="tab-content">
             {% for role, related_objs in related_objects.items %}
-              <div role="tabpanel" class="tab-pane {% if forloop.first %}active{% endif %}" id="id_{{ role|lower }}">
+              <div role="tabpanel" class="tab-pane {% if forloop.first and tab is None or tab == role|lower %}active{% endif %}" id="id_{{ role|lower }}">
                 <br>
                 {% if role == 'Player' %}
                   {% include 'players/_players.html' %}

--- a/apps/sports/views.py
+++ b/apps/sports/views.py
@@ -124,6 +124,9 @@ class SportRegistrationDetailView(LoginRequiredMixin, ContextMixin, generic.View
         for role in SportRegistration.ROLES:
             role_url_mapping[role] = self._get_url_for_role(role, pk=sr.pk)
         context['role_url_mapping'] = role_url_mapping
+
+        tab = self.request.GET.get('tab', None)
+        context['tab'] = tab if tab in [role.lower() for role in sr_roles] else None
         return context
 
     def get(self, request, *args, **kwargs):

--- a/apps/sports/views.py
+++ b/apps/sports/views.py
@@ -126,7 +126,9 @@ class SportRegistrationDetailView(LoginRequiredMixin, ContextMixin, generic.View
         context['role_url_mapping'] = role_url_mapping
 
         tab = self.request.GET.get('tab', None)
-        context['tab'] = tab if tab in [role.lower() for role in sr_roles] else None
+        roles = [role.lower() for role in sr_roles]
+        roles.append('available-roles')
+        context['tab'] = tab if tab in roles else None
         return context
 
     def get(self, request, *args, **kwargs):

--- a/apps/userprofiles/templates/userprofiles/userprofile_update.html
+++ b/apps/userprofiles/templates/userprofiles/userprofile_update.html
@@ -10,14 +10,14 @@
       <div class="col-sm-offset-3 col-sm-6">
         <br><br>
         <ul class="nav nav-tabs nav-justified" role="tablist">
-          <li role="presentation" class="active">
-            <a href="#my_account" role="tab" data-toggle="tab" class="nav-tab">
+          <li role="presentation" class="{% if tab is None or tab == 'my-account' %}active{% endif %}">
+            <a href="#my_account" role="tab" data-toggle="tab" class="nav-tab" data-tab="my-account">
               <i class="fa fa-fw fa-user"></i>
               My Account
             </a>
           </li>
-          <li role="presentation">
-            <a href="#my_sport_registrations" role="tab" data-toggle="tab" class="nav-tab" id="my-sports-tab">
+          <li role="presentation" class="{% if tab == 'my-sports' %}active{% endif %}">
+            <a href="#my_sport_registrations" role="tab" data-toggle="tab" class="nav-tab" id="my-sports-tab" data-tab="my-sports">
               <i class="fa fa-fw fa-list"></i>
               My Sports
             </a>
@@ -27,7 +27,8 @@
         <br>
 
         <div class="tab-content">
-          <div role="tabpanel" class="tab-pane active" id="my_account">
+
+          <div role="tabpanel" class="tab-pane {% if tab is None or tab == 'my-account' %}active{% endif %}" id="my_account">
             <br>
             <div class="panel panel-primary">
               <div class="panel-heading">
@@ -84,7 +85,7 @@
             </div>
           </div>
 
-          <div role="tabpanel" class="tab-pane" id="my_sport_registrations">
+          <div role="tabpanel" class="tab-pane {% if tab == 'my-sports' %}active{% endif %}" id="my_sport_registrations">
             <br>
             <div class="panel panel-primary">
               <div class="panel-heading">

--- a/apps/userprofiles/views.py
+++ b/apps/userprofiles/views.py
@@ -39,6 +39,10 @@ class UserProfileUpdateView(LoginRequiredMixin, SuccessMessageMixin, generic.Upd
         context['data'] = data
         api_tokens = Token.objects.filter(user=self.request.user)
         context['api_token'] = api_tokens.first() if api_tokens.exists() else None
+
+        tab = self.request.GET.get('tab', None)
+        # Handle people manually putting in query strings.
+        context['tab'] = tab if tab in ['my-account', 'my-sports'] else None
         return context
 
     def get_object(self, queryset=None):

--- a/static/js/common.js
+++ b/static/js/common.js
@@ -134,13 +134,13 @@ $(function () {
 
   $("a[data-toggle='tab']").on('shown.bs.tab', function (e) {
     var key = computePersistentTabKey();
-    var targetId = $(e.target).attr('id');
-    setLocalStorageItem(key, '#' + targetId);
+    var targetId = $(e.target).attr('href');
+    setLocalStorageItem(key, targetId);
   });
 
   var key = computePersistentTabKey();
   var elementId = getLocalStorageItem(key);
   if (elementId !== null) {
-    $(elementId).tab('show');
+    $("a[href='" + elementId + "']").tab('show');
   }
 });

--- a/static/js/common.js
+++ b/static/js/common.js
@@ -103,4 +103,44 @@ $(function () {
     history.back();
   });
 
+  var hasLocalStorage = function () {
+    try {
+      var item = 'test';
+      localStorage.setItem(item, item);
+      localStorage.removeItem(item);
+      return true;
+    } catch (e) {
+      return false;
+    }
+  };
+
+  var setLocalStorageItem = function (key, value) {
+    if (!hasLocalStorage()) {
+      return;
+    }
+    localStorage.setItem(key, value);
+  };
+
+  var getLocalStorageItem = function (key) {
+    return hasLocalStorage() ? localStorage.getItem(key) : null;
+  };
+
+  var computePersistentTabKey = function () {
+    var pathname = window.location.pathname;
+    // Convert '/' to '-', omitting the root '/'. This assumes there is a trailing '/'.
+    var key = pathname.substr(1).replace(/\//g, '-');
+    return key.concat('active-tab');
+  };
+
+  $("a[data-toggle='tab']").on('shown.bs.tab', function (e) {
+    var key = computePersistentTabKey();
+    var targetId = $(e.target).attr('id');
+    setLocalStorageItem(key, '#' + targetId);
+  });
+
+  var key = computePersistentTabKey();
+  var elementId = getLocalStorageItem(key);
+  if (elementId !== null) {
+    $(elementId).tab('show');
+  }
 });

--- a/static/js/common.js
+++ b/static/js/common.js
@@ -103,44 +103,13 @@ $(function () {
     history.back();
   });
 
-  var hasLocalStorage = function () {
-    try {
-      var item = 'test';
-      localStorage.setItem(item, item);
-      localStorage.removeItem(item);
-      return true;
-    } catch (e) {
-      return false;
-    }
-  };
-
-  var setLocalStorageItem = function (key, value) {
-    if (!hasLocalStorage()) {
-      return;
-    }
-    localStorage.setItem(key, value);
-  };
-
-  var getLocalStorageItem = function (key) {
-    return hasLocalStorage() ? localStorage.getItem(key) : null;
-  };
-
-  var computePersistentTabKey = function () {
-    var pathname = window.location.pathname;
-    // Convert '/' to '-', omitting the root '/'. This assumes there is a trailing '/'.
-    var key = pathname.substr(1).replace(/\//g, '-');
-    return key.concat('active-tab');
-  };
-
+  // Any tabs on the site can opt into this functionality by adding `data-tab=<value>`.
+  // The corresponding Django view needs to set the `active` class based off of the `tab` query param.
   $("a[data-toggle='tab']").on('shown.bs.tab', function (e) {
-    var key = computePersistentTabKey();
-    var targetId = $(e.target).attr('href');
-    setLocalStorageItem(key, targetId);
+    var tab = $(e.target).data('tab');
+    if (tab) {
+      var baseUrl = window.location.origin + window.location.pathname;
+      window.history.replaceState({}, '', baseUrl + '?tab=' + encodeURIComponent(tab));
+    }
   });
-
-  var key = computePersistentTabKey();
-  var elementId = getLocalStorageItem(key);
-  if (elementId !== null) {
-    $("a[href='" + elementId + "']").tab('show');
-  }
 });


### PR DESCRIPTION
There is a small cosmetic quirk when deactivating your last player/coach/referee/manager. The page refreshes but `?tab=referee` is still in the url. The active tab is correct, just the url is out of sync. I'm not able to change `window.location.reload(true)` to just `window.location.href = ...` and strip off the tab query param because it would effect removing related objects that aren't the last object being removed for that role.  